### PR TITLE
ゴル友をイベントに招待する機能を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -36,6 +36,11 @@ class EventsController < ApplicationController
     rescue StandardError => e
       # do nothing
     end
+
+    # 主催者の場合、イベントに参加していない招待可能なユーザーを取得。
+    if current_user.id == @event.user_id
+      @invitable_users = current_user.invitable_users(@event)
+    end
   end
 
   def create
@@ -110,6 +115,16 @@ class EventsController < ApplicationController
         end
       end
     end
+  end
+
+  def invite
+    @event = Event.find_by!(url_token: params[:url_token])
+    params[:event][:user_ids].each do |user_id|
+      @event.create_notification_invite!(user_id) if user_id.to_i >= 1
+    end
+
+    flash[:notice] = 'ゴル友を招待しました'
+    redirect_to event_path(@event)
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -54,6 +54,7 @@ class Event < ApplicationRecord
   LIKE_ACTION = 'like'.freeze
   PARTICIPATE_ACTION = 'participate'.freeze
   COMMENT_ACTION = 'comment'.freeze
+  INVITE_ACTION = 'invite'.freeze
 
   def to_param
     url_token
@@ -130,6 +131,19 @@ class Event < ApplicationRecord
       notification.checked = true
     end
     notification.save if notification.valid?
+  end
+
+  def create_notification_invite!(user_id)
+    invite_notification = Notification.search_notification(user.id, user_id, id, INVITE_ACTION)
+
+    if invite_notification.blank?
+      notification = user.active_notifications.new(
+        visited_id: user_id,
+        event_id: id,
+        action: INVITE_ACTION
+      )
+      notification.save if notification.valid?
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,7 @@ class User < ApplicationRecord
   has_many :participants, dependent: :destroy
   has_many :participated_events, through: :participants, source: :event
   has_many :comments, dependent: :destroy
+  has_many :relationships
   has_many :active_relationships, class_name: 'Relationship',
                                   foreign_key: 'follower_id',
                                   dependent: :destroy
@@ -153,6 +154,19 @@ class User < ApplicationRecord
       end
     end
     ages_name
+  end
+
+  def invitable_users(event)
+    invitable_users =
+      User
+      .joins('INNER JOIN relationships ON users.id = relationships.followed_id')
+      .where(relationships: { follower_id: id })
+      .where.not(relationships:
+          { followed_id:
+            Notification
+              .where(event_id: event.id)
+              .where(action: Event::INVITE_ACTION)
+              .select('visited_id') })
   end
 
   private

--- a/app/views/events/_participants_list_modal.html.erb
+++ b/app/views/events/_participants_list_modal.html.erb
@@ -1,0 +1,31 @@
+<div class="modal modal-default" id="participants-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        ゴル友を招待する
+      </div>
+      <div class="modal-body overflow-auto" style="height:300px">
+        <p class="text-left">招待するゴル友を選択してください。</p>
+          <div class="participants-list">
+            <%= form_with(model: event, url: invite_event_path(event), local: true) do |f| %>
+              <ul>
+                <% users.each do |user| %>
+                  <li>
+                    <%= f.check_box :user_ids, { multiple: true }, user.id %>
+                    <%= render 'users/user_card_mini_nolink', user_card: user %>
+                  </li>
+                <% end %>
+              </ul>
+              <div class="text-left">
+                <%= f.submit "招待する", class: "btn base-btn bg-info text-white" %>
+              </div>
+            <% end %>
+          </div>
+        <br>
+      </div>
+      <div class="modal-footer" id="modal-btn">
+        <button type="button" class="btn btn-sm" data-dismiss="modal">キャンセル</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -148,6 +148,12 @@
               </div>
             <% end %>
           <% end %>
+        <% else %>
+          <div class="btn-field mb-2">
+            <button type="button" class="btn base-btn bg-info text-white" data-toggle="modal"
+              data-target="#participants-modal">ゴル友を招待</button>
+          </div>
+          <%= render 'events/participants_list_modal', { event: @event, users: @invitable_users } %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/users/_user_card_mini_nolink.html.erb
+++ b/app/views/users/_user_card_mini_nolink.html.erb
@@ -1,0 +1,8 @@
+<% if user_card.avatar?%>
+  <%= image_tag user_card.avatar.url, class: 'avatar-img-mini rounded-circle' %>
+<% else %>
+  <%= image_tag 'fallback/default_user_avatar.png', class: 'avatar-img-mini rounded-circle' %>
+<% end %>
+<span class="user-name">
+  <%= user_card.username %>
+</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
     collection do
       get :search, :autocomplete_search, :golf_course_info
     end
+    member do
+      patch :invite
+    end
   end
 
   resources :relationships, only: [:create, :destroy]


### PR DESCRIPTION
イベント詳細画面からゴル友を招待する機能を追加しました。
招待できるのは主催者がフォローしており、未招待のゴル友のみとしました。