### PR TITLE
終了したイベントを参加者に通知するタスクを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'valid_email'
+gem 'whenever', require: false
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
     childprocess (3.0.0)
+    chronic (0.10.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -380,6 +381,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -440,6 +443,7 @@ DEPENDENCIES
   valid_email
   web-console (>= 3.3.0)
   webdrivers
+  whenever
 
 RUBY VERSION
    ruby 2.7.0p0

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -34,6 +34,8 @@ module NotificationsHelper
     when Event::INVITE_ACTION
       @event_invitation = EventInvitation.search_invitation(notification.event_id, notification.visited_id)
       "#{notificated_event}に招待されました"
+    when Event::CLOSE_ACTION
+      "#{notificated_event}はいかかでしたか？"
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -56,6 +56,7 @@ class Event < ApplicationRecord
   PARTICIPATE_ACTION = 'participate'.freeze
   COMMENT_ACTION = 'comment'.freeze
   INVITE_ACTION = 'invite'.freeze
+  CLOSE_ACTION = 'close'.freeze
 
   def to_param
     url_token

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -49,6 +49,9 @@
         <% when EventInvitation::REJECTED %>
           参加を拒否しました
         <% end %>
+      <% when Event::CLOSE_ACTION %>
+        よければイベントの感想をコメントしませんか？<br>
+        <%= visitor.username %>さんのフォローはお済みですか？
       <% end %>
     </span>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module GolfMenta
+module GolfCommu
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
@@ -27,14 +27,17 @@ module GolfMenta
     config.generators do |g|
       g.javascripts false
       g.stylesheets false
-      g.test_framework :rspec, 
-            view_specs: false, 
-            helper_specs: false, 
-            controller_specs: false, 
+      g.test_framework :rspec,
+            view_specs: false,
+            helper_specs: false,
+            controller_specs: false,
             routing_specs: false
     end
 
     # 認証トークンをremoteフォームに埋め込む
     config.action_view.embed_authenticity_token_in_remote_forms = true
+
+    config.autoload_paths += %W(#{config.root}/lib)
+    config.enable_dependency_loading = true
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,6 +40,9 @@ set :bundle_flags,      '--quiet'
 set :bundle_path,       nil
 set :bundle_without,    nil
 
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
+
 namespace :deploy do
   desc 'Config bundler'
   task :config_bundler do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,6 @@
+set :output, 'log/crontab.log'
+set :environment, ENV['RAILS_ENV']
+
+every 1.day do
+  rake "create_notification:create_event_close_notification"
+end

--- a/lib/tasks/create_notification.rake
+++ b/lib/tasks/create_notification.rake
@@ -1,0 +1,32 @@
+namespace :create_notification do
+  desc 'イベント終了通知の作成'
+  task create_event_close_notification: :environment do
+    logger = Logger.new 'log/create_notification.log'
+
+    # イベント終了通知未作成のイベントを取得
+    uncreated_notification_events =
+      Event.joins("LEFT JOIN notifications ON events.id = notifications.event_id AND action = '#{Event::CLOSE_ACTION}'")
+           .where('events.event_date < ?', Date.today)
+           .where(notifications: { id: nil })
+
+    uncreated_notification_events.find_each do |event|
+      # 主催者以外の参加者に対して終了通知を作成
+      event.participants.each do |participant|
+        next unless event.user_id != participant.user_id
+
+        notificaton = Notification.new(
+          visitor_id: event.user_id,
+          visited_id: participant.user_id,
+          event_id: event.id,
+          action: Event::CLOSE_ACTION
+        )
+        notificaton.save!
+      end
+    rescue StandardError => e
+      logger.error "event_id: #{event.id}でエラーが発生"
+      logger.error e
+      logger.error e.backtrace.join("\n")
+      next
+    end
+  end
+end


### PR DESCRIPTION
終了したイベントを参加者に通知するタスクを追加しました。
通知では、コメントとフォローを促すようにメッセージを追加しました。