### PR TITLE
天気情報が取得できなかった場合の文言を修正（その他修正含む）

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,8 +38,10 @@ class EventsController < ApplicationController
     end
 
     # 主催者の場合、イベントに参加していない招待可能なユーザーを取得。
-    if current_user.id == @event.user_id
-      @invitable_users = User.invitable_users(@event)
+    if user_signed_in?
+      if current_user.id == @event.user_id
+        @invitable_users = User.invitable_users(@event)
+      end
     end
   end
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -96,7 +96,7 @@
             </td>
             <td>
               <% if @wheather_condition.size == 0 %>
-                ※5日前から表示されます
+                天気情報が取得できませんでした
               <% else %>
                 <table>
                   <% @wheather_condition.each do |weather| %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module GolfCommu
+module GolCommu
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2


### PR DESCRIPTION
天気情報が取得できなかった場合の文言を修正しました。
あと、ログイン時のみ招待可能なユーザーを取得する処理を通るように修正しました。