### PR TITLE
S3に保存する画像をCloudFront経由で配信するように変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = 'https://assets.golcommu.com'
+  config.action_controller.asset_host = ENV['AWS_ASSETS_CDN_HOST']
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -9,5 +9,6 @@ if Rails.env.production?
       region:                ENV['AWS_S3_REGION'],
       path_style:            true
     }
+    config.asset_host = ENV['AWS_IMAGE_CDN_HOST']
   end
 end


### PR DESCRIPTION
S3に保存する画像をCloudFront経由で配信するように変更しました。
また、CloudFrontのURLを環境変数から取得するように変更しました。