### PR TITLE
create_notification_like!をLikeモデルのafter_createに移動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@
 /config/master.key
 
 # アップロードされたテスト画像を無視する
-/public/uploads
+/public/avatar
+/public/event-image
 
 # dotenv
 /.env


### PR DESCRIPTION
- likeコントローラーからcreate_notification_like!を呼び出していましたが、Likeモデルのafter_createに移動しました。
- アップロード画像のパスを変更したため、.gitignoreファイルを修正し該当パスをリポジトリ管理から除外しました。