### PR TITLE
create_notification〜の各メソッドをafter_createに移動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 # アップロードされたテスト画像を無視する
 /public/avatar
 /public/event-image
+/public/uploads
 
 # dotenv
 /.env

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,7 +4,6 @@ class LikesController < ApplicationController
   def create
     @event = Event.find(params[:event_id])
     @event.like(current_user) unless @event.already_liked?(current_user)
-    @event.create_notification_like!(current_user)
     respond_to do |format|
       format.html { redirect_to request.referer || root_url }
       format.js

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -6,7 +6,6 @@ class ParticipantsController < ApplicationController
     unless @event.already_participated?(current_user)
       @event.participate(current_user)
     end
-    @event.create_notification_participate!(current_user)
 
     update_event_invitation_status(EventInvitation::ACCEPTED)
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -86,55 +86,6 @@ class Event < ApplicationRecord
     participated_users.include?(user)
   end
 
-  def create_notification_like!(current_user)
-    like_notification = Notification.search_notification(current_user.id, user_id, id, LIKE_ACTION)
-
-    if like_notification.blank?
-      notification = current_user.active_notifications.new(
-        visited_id: user_id,
-        event_id: id,
-        action: LIKE_ACTION
-      )
-      notification.save! if notification.valid?
-    end
-  end
-
-  def create_notification_participate!(current_user)
-    participant_notification = Notification.search_notification(current_user.id, user_id, id, PARTICIPATE_ACTION)
-
-    if participant_notification.blank?
-      notification = current_user.active_notifications.new(
-        visited_id: user_id,
-        event_id: id,
-        action: PARTICIPATE_ACTION
-      )
-      notification.save! if notification.valid?
-    end
-  end
-
-  def create_notification_comment!(current_user, comment_id)
-    visited_ids = Comment.select(:user_id).where(event_id: id).where.not(user_id: current_user.id).distinct
-    visited_ids.each do |visited_id|
-      save_notification_comment!(current_user, comment_id, visited_id['user_id'])
-    end
-    if visited_ids.blank?
-      save_notification_comment!(current_user, comment_id, user_id)
-    end
-  end
-
-  def save_notification_comment!(current_user, comment_id, visited_id)
-    notification = current_user.active_notifications.new(
-      visited_id: visited_id,
-      event_id: id,
-      comment_id: comment_id,
-      action: COMMENT_ACTION
-    )
-    if notification.visitor_id == notification.visited_id
-      notification.checked = true
-    end
-    notification.save! if notification.valid?
-  end
-
   def create_notification_invite!(user_id)
     invite_notification = Notification.search_notification(user.id, user_id, id, INVITE_ACTION)
 

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -17,4 +17,21 @@ class Like < ApplicationRecord
   belongs_to :event
   belongs_to :user
   validates :event_id, uniqueness: { scope: :user_id }
+
+  after_create :create_notification_like!
+
+  private
+
+  def create_notification_like!
+    like_notification = Notification.search_notification(user_id, user_id, event_id, Event::LIKE_ACTION)
+
+    if like_notification.blank?
+      notification = user.active_notifications.new(
+        visited_id: event.user_id,
+        event_id: event_id,
+        action: Event::LIKE_ACTION
+      )
+      notification.save! if notification.valid?
+    end
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -17,4 +17,23 @@ class Participant < ApplicationRecord
   belongs_to :event
   belongs_to :user
   validates :event_id, uniqueness: { scope: :user_id }
+
+  after_create :create_notification_participate!
+
+  private
+
+  def create_notification_participate!
+    participant_notification = Notification.search_notification(user_id, event.user_id, event_id, Event::PARTICIPATE_ACTION)
+
+    unless user_id == event.user_id
+      if participant_notification.blank?
+        notification = user.active_notifications.new(
+          visited_id: event.user_id,
+          event_id: event_id,
+          action: Event::PARTICIPATE_ACTION
+        )
+        notification.save! if notification.valid?
+      end
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -18,8 +18,9 @@ require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
   let!(:user) { create(:user) }
+  let!(:other_user) { create(:user) }
   let!(:event) { create(:event, user: user) }
-  let!(:comment) { create(:comment, event: event, user: user) }
+  let!(:comment) { build(:comment, event: event, user: user) }
 
   describe '検証' do
     describe '存在性の検証' do
@@ -49,6 +50,20 @@ RSpec.describe Comment, type: :model do
         comment.content = 'a' * 241
         comment.valid?
         expect(comment.errors).to be_added(:content, :too_long, count: 240)
+      end
+    end
+
+    describe 'after_createの確認' do
+      example '主催者だけがイベントにコメントした際の通知が増加しないこと' do
+        expect do
+          create(:comment, event: event, user: user)
+        end.to change(Notification, :count).by(0)
+      end
+
+      example '主催者以外がイベントにコメントした際の通知が１件増加すること' do
+        expect do
+          create(:comment, event: event, user: other_user)
+        end.to change(Notification, :count).by(1)
       end
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -179,24 +179,6 @@ RSpec.describe Event, type: :model do
       other_event.stop_participate(user)
       expect(other_event.already_participated?(user)).to be_falsey
     end
-
-    example 'イベントにLikeした際の通知が１件増加すること' do
-      expect do
-        event.create_notification_like!(user)
-      end.to change(Notification, :count).by(1)
-    end
-
-    example 'イベントに参加した際の通知が１件増加すること' do
-      expect do
-        event.create_notification_participate!(user)
-      end.to change(Notification, :count).by(1)
-    end
-
-    example 'イベントにコメントした際の通知が１件増加すること' do
-      expect do
-        event.create_notification_comment!(user, comment.id)
-      end.to change(Notification, :count).by(1)
-    end
   end
 
   describe '関連性' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -27,9 +27,9 @@ require 'rails_helper'
 
 RSpec.describe Event, type: :model do
   let!(:user) { create(:user) }
+  let!(:other_user) { create(:user) }
   let!(:event) { create(:event, user: user) }
   let!(:other_event) { create(:event, user: user) }
-  let!(:comment) { create(:comment, event: event, user: user) }
 
   describe '検証' do
     describe '存在性の検証' do
@@ -204,6 +204,7 @@ RSpec.describe Event, type: :model do
     end
 
     example 'イベントを削除すると関連する通知も削除されること' do
+      create(:comment, event: event, user: other_user)
       expect do
         event.destroy
       end.to change(Notification, :count).by(-1)

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :bigint
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_likes_on_event_id  (event_id)
+#  index_likes_on_user_id   (user_id)
+#
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  let!(:user) { create(:user) }
+  let!(:other_event) { create(:event, user: user) }
+
+  describe '検証' do
+    describe 'after_createの確認' do
+      example 'イベントにLikeした際の通知が１件増加すること' do
+        expect do
+          other_event.like(user)
+        end.to change(Notification, :count).by(1)
+      end
+    end
+  end
+end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: participants
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :bigint
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_participants_on_event_id  (event_id)
+#  index_participants_on_user_id   (user_id)
+#
+require 'rails_helper'
+
+RSpec.describe Participant, type: :model do
+  let!(:user) { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:event) { create(:event, user: user) }
+  let!(:other_event) { create(:event, user: other_user) }
+
+  describe '検証' do
+    describe 'after_createの確認' do
+      example '自分が主宰したイベントに参加した際は通知が増加しないこと' do
+        expect do
+          event.participate(user)
+        end.to change(Notification, :count).by(0)
+      end
+
+      example '他の主催者のイベントに参加した際の通知が１件増加すること' do
+        expect do
+          other_event.participate(user)
+        end.to change(Notification, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- create_notification〜の各メソッドをafter_createに移動しました。
  - ついでに、主催者が参加したときに主催者自身にも通知が作成される不具合を解消しました。
  - Rspecのテストも変更しました。
- public/uploadsをGitの管理から除外しました。